### PR TITLE
Added dactyl-lynx-keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ already about dactyl 😛)
 * [dactyl-ez2print: Easy-to-print ortholinear dactyl-like keyboard](https://github.com/ramonimbao/dactyl-ez2print)
 * [dactyl-flatpacked: A reimagined dactyl using slotted rib pieces to create the countoured surface instead of a solid 3D printed part.](https://github.com/nickcoutsos/dactyl-flatpacked/)
 * [dactyl-deskmount: A variant of the dactyl-keyboard that doesn't impose significant extra height above my desk surface.](https://github.com/nickcoutsos/dactyl-deskmount/)
+* [dactyl-lynx-keyboard: A variant of the Dactyl ported to Python, with more aggressive tenting, almost-vertical thumb clusters, and adjustable feet.](https://github.com/whitelynx/dactyl-lynx-keyboard)
 
 ### Manuform
 


### PR DESCRIPTION
Added my Dactyl variant, [the Dactyl Lynx](https://github.com/whitelynx/dactyl-lynx-keyboard). It's ported to Python (using SolidPython2 and [spkb](https://github.com/whitelynx/spkb)) and has several changes including hot-swap socket support, almost-vertical thumb clusters, adjustable feet, TrackPoint mounting, and more.